### PR TITLE
fixing path to ssl/choria_security/public_certs/

### DIFF
--- a/docs/content/configuration/aaa/index.md
+++ b/docs/content/configuration/aaa/index.md
@@ -88,7 +88,7 @@ $ mco choria request_cert --certname bob
 
 ### Revoking access
 
-Public certificates are distributed automatically but will never be removed.  To remove them you have to manually arrange for the files to be deleted from all nodes, perhaps using Puppet, before a new one can be distributed.  These live in */etc/puppetlabs/mcollective/choria_security/public_certs*.
+Public certificates are distributed automatically but will never be removed.  To remove them you have to manually arrange for the files to be deleted from all nodes, perhaps using Puppet, before a new one can be distributed.  These live in <i>/etc/puppetlabs/puppet/choria_security/public_certs</i>.
 
 ### Privileged certificates
 

--- a/docs/content/reference/security/index.md
+++ b/docs/content/reference/security/index.md
@@ -61,7 +61,7 @@ be approved if you use something like the [REST](../../development/rest) feature
 On the server you have to set _securityprovider = choria_, assuming you have a working
 Puppet 4 AIO setup. This plugin itself has no options to change any paths to certificates.
 
-Client certificates are cached in _/etc/puppetlabs/mcollective/choria_security/public_certs_,
+Client certificates are cached in <i>/etc/puppetlabs/puppet/choria_security/public_certs</i>,
 the directory will be created if it does not exist.  There is no case where the cert
 will be overwritten once cached, changing a cert for user entails you having to remove
 the cert from the servers.


### PR DESCRIPTION
My choria_security/public_certs are getting created under /etc/puppetlabs/puppet/ssl/, so I'm assuming the paths in the doc are wrong and have updated them.