### PR TITLE
doc note about managing dependencies by hand

### DIFF
--- a/docs/content/deployment/mcollective/index.md
+++ b/docs/content/deployment/mcollective/index.md
@@ -16,6 +16,11 @@ Your mcollective config files in */etc/puppetlabs/mcollective* should be factory
 
 All nodes should have the _choria-mcollective_ module on them, by default every node becomes a MCollective Server ready to be managed via MCollective:
 
+{{% notice info %}}
+The choria/mcollective_choria module has a number of [dependencies](https://forge.puppet.com/choria/mcollective_choria/dependencies), if you use R10k to manage environments please be sure to fetch all dependencies.
+{{% notice %}}
+
+
 ```puppet
 node "server1.example.net" {
   include mcollective

--- a/docs_0.0.27/content/deployment/mcollective/index.md
+++ b/docs_0.0.27/content/deployment/mcollective/index.md
@@ -37,6 +37,3 @@ mcollective::client: true
 mcollective::server: false
 ```
 
-## Managing Choria Modules Yourself
-
-Installing the Forge module <i>choria-mcollective_choria</i> will pull in all the necessary dependencies. If however if you cannot access the Forge, or you use r10k, you will need to install the dependencies in <i>metadata.json</i> by hand.

--- a/docs_0.0.27/content/deployment/mcollective/index.md
+++ b/docs_0.0.27/content/deployment/mcollective/index.md
@@ -37,3 +37,6 @@ mcollective::client: true
 mcollective::server: false
 ```
 
+## Managing Choria Modules Yourself
+
+Installing the Forge module <i>choria-mcollective_choria</i> will pull in all the necessary dependencies. If however if you cannot access the Forge, or you use r10k, you will need to install the dependencies in <i>metadata.json</i> by hand.


### PR DESCRIPTION
When following the docs I was confused by the line "involves just including 1 module" and why I appeared to be missing so many things. Then I realised most people will do a 'puppet module install' and it will grab all the dependencies for you, except for me who uses r10k and a private Git Lab server behind a corporate firewall :-) I added a little footnote about making sure you grab the necessary dependencies - probably common sense... If you think it's too obvious feel free to reject.