### PR TITLE
Newer gem version to avoid some deprecation warnings - cosmetic

### DIFF
--- a/docs_0.8.0/content/playbooks/data/index.md
+++ b/docs_0.8.0/content/playbooks/data/index.md
@@ -102,7 +102,7 @@ To use the Consul store you should have the `diplomat` gem installed in your Pup
 
 ```yaml
 mcollective_choria::gem_dependencies:
-  "diplomat": "1.1.0"
+  "diplomat": "2.0.2"
 ```
 
 The Consul store requires you to have a local [Consul Agent](https://consul.io) instance running on your node where you run *mco playbook* from.  Configuring a Consul cluster is out of scope for this guide.


### PR DESCRIPTION
Tested with this version of the gem, on el7.

Still able to get a lock using consul.

Avoid a deprecation warning burst (repeated messages : 'WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0.').

For some reason, my text editor also added a newline at EOF.
