### PR TITLE
Spelling, formatting

### DIFF
--- a/docs/content/about/_index.md
+++ b/docs/content/about/_index.md
@@ -4,7 +4,7 @@ pre = "<b>1. </b>"
 menu = "about"
 weight = 10
 +++
-
+ 
 ## Overview
 
 Choria is an ongoing project to create a new Orchestration System with roots in The Marionette Collective (mcollective).  It's part trivially installable mcollective and part brand new development of turn key end user features, new content and modernization.

--- a/docs/content/about/mcollective/_index.md
+++ b/docs/content/about/mcollective/_index.md
@@ -14,7 +14,7 @@ The Choria project provides a path forward for users who wish to keep using MCol
 
 We welcome users of The Marionette Collective who wish to continue using it, we have gone to great length to ensure you can continue as always - and the Choria project added a lot of new and exciting features to the platform.
 
-While the Choria project builds heavily ontop of the foundation laid by The Marionnette Collective this does not mean an end or even a significant hurdle for this project.
+While the Choria project builds heavily on top of the foundation laid by The Marionnette Collective this does not mean an end or even a significant hurdle for this project.
 
 Today in Puppet 5.x there is no concern everything continues to work, once Puppet 6 is released there will be a short delay until the Choria project is ready to run on Puppet 6.
 

--- a/docs/content/adapters/natsstream/_index.md
+++ b/docs/content/adapters/natsstream/_index.md
@@ -15,21 +15,21 @@ Given a NATS Streaming server setup with a cluster id of `prod_1`, the following
 class{"choria::broker":
   adapters => {
     "node_data" => {
-      "stream" => {
-        "type" => "natsstream",
+      "stream"  => {
+        "type"      => "natsstream",
         "clusterid" => "prod_1",
-        "topic" => "node_data",
-        "workers" => 10,
-        "servers" => [
+        "topic"     => "node_data",
+        "workers"   => 10,
+        "servers"   => [
           "stan1.example.net:4222",
           "stan2.example.net:4222",
           "stan3.example.net:4222"
         ]
       },
       "ingest" => {
-        "topic" => "mcollective.broadcast.agent.discovery",
+        "topic"    => "mcollective.broadcast.agent.discovery",
         "protocol" => "request",
-        "workers" => 10
+        "workers"  => 10
       }
     }
   }

--- a/docs/content/concepts/cli/_index.md
+++ b/docs/content/concepts/cli/_index.md
@@ -171,7 +171,7 @@ The order of events in this process are:
  * Show any results that were out of the ordinary
  * Show some statistics
 
-Chroia client applications aim to only provide the most relevant
+Choria client applications aim to only provide the most relevant
 information.  In this case, the application is not showing verbose
 information about the nine *OK* results, since the most important issue
 is the one *Failure*. Keep this in mind when viewing the results of

--- a/docs/content/concepts/related/_index.md
+++ b/docs/content/concepts/related/_index.md
@@ -4,7 +4,7 @@ weight = 205
 toc = true
 +++
 
-There are a number of related projects in the project GitHub respositories, I'll call out a few key ones here:
+There are a number of related projects in the project GitHub repositories, I'll call out a few key ones here:
 
 ## Choria Plugins
 
@@ -32,7 +32,7 @@ A video demonstrating this capability can be seen below:
 
 ## Prometheus Streams
 
-Prometheus is a very flexible and scalable monitoring system but it has a very unfortunate Pull based system that requires vast amount of network ports to be opened between DCs. The [Choria Prometheus Streams](https://github.com/choria-io/prometheus-streams) project lets you poll in your remote DCs and have the metrics streamed over a NATS Streaming Server - and optionaly replicated using the Choria Stream Replicator.
+Prometheus is a very flexible and scalable monitoring system but it has a very unfortunate Pull based system that requires vast amount of network ports to be opened between DCs. The [Choria Prometheus Streams](https://github.com/choria-io/prometheus-streams) project lets you poll in your remote DCs and have the metrics streamed over a NATS Streaming Server - and optionally replicated using the Choria Stream Replicator.
 
 Using this you can create a single pane of glass for multiple data centers.  It's not for all uses - in fact it has a very narrow focus, review it's README carefully before adopting it.
 

--- a/docs/content/concepts/terminology/_index.md
+++ b/docs/content/concepts/terminology/_index.md
@@ -85,7 +85,7 @@ See [Federations of Collectives](../../federation)
 
 ## Marionette Collective / MCollective
 
-A Orchestration System written by the author of Choria and sold to Puppet Inc. This system was included in Puppet since 2009 and is being sunset late 2018.
+A Orchestration System written by the author of Choria and sold to Puppet Inc. This system was included in Puppet since 2009 and sunset in late 2018.
 
 Choria builds on many of the ideas, modernizes a lot of the concepts and provide a compatibility framework for MCollective agents while looking towards the future.
 

--- a/docs/content/configuration/aaa/_index.md
+++ b/docs/content/configuration/aaa/_index.md
@@ -88,7 +88,7 @@ $ mco choria request_cert --certname bob
 
 ### Revoking access
 
-Public certificates are distributed automatically but will never be removed.  To remove them you have to manually arrange for the files to be deleted from all nodes, perhaps using Puppet, before a new one can be distributed.  These live in <i>/etc/puppetlabs/puppet/choria_security/public_certs</i>.
+Public certificates are distributed automatically but will never be removed.  To remove them you have to manually arrange for the files to be deleted from all nodes, perhaps using Puppet, before a new one can be distributed.  These live in */etc/puppetlabs/puppet/choria_security/public_certs*.
 
 ### Privileged certificates
 

--- a/docs/content/configuration/choria_server/_index.md
+++ b/docs/content/configuration/choria_server/_index.md
@@ -4,7 +4,7 @@ toc = true
 weight = 260
 +++
 
-The *Choria Server* is a replacement for the old *mcollectived* daemon.  This new daemon is written in Golang and it's very fast, light weight and embeddable while providing a MCollective compatability layer for hosting old agents.
+The *Choria Server* is a replacement for the old *mcollectived* daemon.  This new daemon is written in Golang and it's very fast, light weight and embeddable while providing a MCollective compatibility layer for hosting old agents.
 
 {{% notice tip %}}
 If your node runs Puppet 6 it will already be running the Choria Server

--- a/docs/content/configuration/pki/ca/_index.md
+++ b/docs/content/configuration/pki/ca/_index.md
@@ -4,7 +4,7 @@ toc = true
 weight = 100
 +++
 
-While Choria is configured by default to use the Puppet CA the system does support custom Certificate Authorities including Intermediatries.  You can use any software to produce these certificates as long as they make compliant x509 certificates.
+While Choria is configured by default to use the Puppet CA the system does support custom Certificate Authorities including intermediaries.  You can use any software to produce these certificates as long as they make compliant x509 certificates.
 
 This section will guide you through the creation of a layered CA setup for a Choria network using the [Cloudflare's PKI toolkit](https://cfssl.org/).
 
@@ -12,10 +12,10 @@ This section will guide you through the creation of a layered CA setup for a Cho
 
 This guide will cover the following:
 
- * Creating a *Example Root CA* that is used to sign a per datacenter intermediate CA
- * Creating a *London CA* and a *New York CA* that issues certificates in each datacenter
- * Create user certificates in each datacenter and configure Choria CLI
- * Configure individual servers in each data center
+ * Creating a *Example Root CA* that is used to sign a per datacentre intermediate CA
+ * Creating a *London CA* and a *New York CA* that issues certificates in each datacentre
+ * Create user certificates in each datacentre and configure Choria CLI
+ * Configure individual servers in each datacentre
 
 What this guide will not cover:
 
@@ -23,7 +23,7 @@ What this guide will not cover:
  * How to get the certificates on every node, this step is essentially going to be unique per site, we cannot realistically cover this for everyone. The [Choria Server Provisioner](https://github.com/choria-io/provisioning-agent) can enroll nodes in any CA with an API
  * Certificate revocation and renewal
  * How to use CFSSL in detail or its deployment best practices
-  * For documentation on the CFSSL project, and how to run it in a client/server fasion, please visit the [Cloudlare CFSSL documentation repo](https://github.com/cloudflare/cfssl/tree/master/doc)
+  * For documentation on the CFSSL project, and how to run it in a client/server fashion, please visit the [Cloudlare CFSSL documentation repo](https://github.com/cloudflare/cfssl/tree/master/doc)
 
 ## Requirements
 
@@ -192,7 +192,7 @@ This states that when signing a request from a particular server it should be ab
 
 When creating infrastructure with TLS and x509 certificates, you have several options.  At minimum, all servers will need to have a copy of the `root_ca.pem` file.  Servers should have a copy of their local intermediate CA (in this example, `london_ca.pem`) file in their CA bundle (as shown below), and clients can optionally present their own local intermediate CAs as part of their negotiation - this is particularly useful in cross DC requests where you might not have distributed the CA bundle universally, or have rotated the remote intermediate CA.
 
-In all cases, the certificate file on disk should contain the canoconical certificate of the _server_ or _client_ first, _then_ the intermediate CA(s).  It should not contain the root CA file.
+In all cases, the certificate file on disk should contain the canonical certificate of the _server_ or _client_ first, _then_ the intermediate CA(s).  It should not contain the root CA file.
 
 The CA root bundle ordering does not matter, but by convention the root CA should be present at the top.
 

--- a/docs/content/configuration/puppetdb/_index.md
+++ b/docs/content/configuration/puppetdb/_index.md
@@ -6,7 +6,7 @@ weight = 210
 
 Choria includes a [PuppetDB](https://docs.puppet.com/puppetdb/) based discovery plugin but it's not enabled by default.
 
-This is an advanced PuppetDB plugin that is subcollective aware and supports node, facts with `dot notation`, class and agent filters. It uses the new _Puppet PQL_ under the hood and so requires a very recent PuppetDB.
+This is an advanced PuppetDB plugin that is Subcollective aware and supports node, facts with `dot notation`, class and agent filters. It uses the new _Puppet PQL_ under the hood and so requires a very recent PuppetDB.
 
 Using it you get a very fast discovery workflow but without the awareness of which nodes are actually up and responding, it's suitable for situations where you have a stable network, or really care to know when known machines are not responding as is common during software deployments. It makes a very comfortable to use default discovery plugin.
 

--- a/docs/content/deployment/_index.md
+++ b/docs/content/deployment/_index.md
@@ -12,4 +12,3 @@ Choria is designed to install MCollective very easily, the installation is compl
 After following this guide you will have a fully functional MCollective set up with TLS encryption, full Authentication, Authorization and Auditing and several useful plugins configured.
 
 Even if you have to do things like open up Firewall ports it's anticipated that deploying MCollective using Choria should not take longer than 1 hour.
-

--- a/docs/content/deployment/broker/_index.md
+++ b/docs/content/deployment/broker/_index.md
@@ -85,7 +85,7 @@ node "nats1.example.net" {
 A note about large deploys such as when you have many thousands of nodes connected to a single NATS server.  NATS has no problem handling this but your kernel might consider the large amount of reconnects after you restarted NATS as a DDoS attempt and throttle the SYN packets.
 
 {{% notice tip %}}
-You can use the <a href="https://forge.puppet.com/thias/sysctl">thias/sysctl</a> module to manage this
+You can use the [thias/sysctl](https://forge.puppet.com/thias/sysctl) module to manage kernel parameters
 {{% /notice %}}
 
 You can overcome this by adjusting these sysctl settings:

--- a/docs/content/deployment/dns/_index.md
+++ b/docs/content/deployment/dns/_index.md
@@ -4,7 +4,7 @@ weight = 120
 toc = true
 +++
 
-By default as per Puppet behaviour the Puppet Master, Puppet CA and NATS brokers are all found on the name _puppet_.  If you are doing a single node NATS installation on the Puppet Master called _puppet_ you do not neeed to configure anything and can continue to the next page.
+By default as per Puppet behaviour the Puppet Master, Puppet CA and NATS brokers are all found on the name _puppet_.  If you are doing a single node NATS installation on the Puppet Master called _puppet_ you do not need to configure anything and can continue to the next page.
 
 When not using _puppet_ you can configure these settings manually but we strongly suggest you use SRV records if at all possible.
 

--- a/docs/content/deployment/next-steps/_index.md
+++ b/docs/content/deployment/next-steps/_index.md
@@ -29,7 +29,7 @@ The active configuration used in Choria comes from using Puppet AIO defaults, qu
 records and reading configuration files.  The below information shows the completely resolved
 configuration that will be used when running Choria commands
 
-MCollective selated:
+MCollective related:
 
  MCollective Version: 2.9.1
   Client Config File: /etc/puppetlabs/mcollective/client.cfg
@@ -103,7 +103,7 @@ Summary of SRV Used:
 Finished processing 3 / 3 hosts in 228.40 ms
 ```
 
-Here we observe 3 nodes with 1 connected to *puppet1.example.net:4222* and 2 connected to *puppet2.example.net:4222*.  Add *--display allways* for much more details.
+Here we observe 3 nodes with 1 connected to *puppet1.example.net:4222* and 2 connected to *puppet2.example.net:4222*.  Add *--display always* for much more details.
 
 From the shell you set up the user in lets check the version of _puppet-agent_ installed on your nodes:
 

--- a/docs/content/deployment/requirements/_index.md
+++ b/docs/content/deployment/requirements/_index.md
@@ -8,7 +8,7 @@ toc = true
 
 Deploying MCollective with Choria is broken into the following main steps that the menu on the left guides you through:
 
-  * Decide your desired Choria Broker middleware topology and deploy it
+  * Decide on your desired Choria Broker middleware topology and deploy it
   * If required configure DNS records or manual host locations
   * Configure MCollective using the [choria/choria](https://forge.puppet.com/choria/choria) module
   * Create your first users and their authorization rules

--- a/docs/content/development/_index.md
+++ b/docs/content/development/_index.md
@@ -12,4 +12,4 @@ On the nodes the primary focus will be around _Agents_ which are API's your node
 
 On your _Client_ - where you run _mco ...._ commands - the interaction comes in the form of API clients, CLI clients or specialised tools like Playbooks.  You can use the APIs to write your own custom clients to manage your infrastructure in any way you choose such as custom daemons that react to outages and do remediation by interacting with the Agents on your nodes via the APIs.
 
-A large focus of this work is in adapting the client and agent model created in The Marionette Collective and having Choria present a compatability layer, the documentation here is largely adapted from this legacy system.
+A large focus of this work is in adapting the client and agent model created in The Marionette Collective and having Choria present a compatibility layer, the documentation here is largely adapted from this legacy system.

--- a/docs/content/development/mcorpc/_index.md
+++ b/docs/content/development/mcorpc/_index.md
@@ -61,7 +61,7 @@ Note: Please see the [agents](agents/) and [clients](clients/) pages for a thoro
 But you can still write your own clients, it's incredibly simple, full details of a client is out of scope for the introduction - see the [Writing Clients](clients/) page instead for full details - but here is some sample code to do the same call as above including full discovery and help output:
 
 ```ruby
-#!/bin/env ruby
+#!/usr/bin/env ruby
 
 require "mcollective"
 

--- a/docs/content/development/mcorpc/agents/_index.md
+++ b/docs/content/development/mcorpc/agents/_index.md
@@ -80,7 +80,6 @@ You'll notice it comes in two parts, the agent definition in the DDL file, and t
 
 The agent name is derived from the class name, the example code creates the ruby class *MCollective::Agent::Echo*, the agent name for this would be *echo*.
 
-
 ## Help and the Data Description Language
 
 We have a file that goes together with an agent implementation which is used to describe the agent in detail.  This is referred to as the ddl file, _$libdir/mcollective/agent/echo.ddl_ in the previous example.
@@ -88,7 +87,6 @@ We have a file that goes together with an agent implementation which is used to 
 The DDL file can be used to generate help texts, and to declare the validation that arguments must pass.  This information helps us in making more robust clients and can be used to auto generate user interfaces.
 
 We'll not say much more about the DDL here, for more details read the [DDL](../ddl/) reference.
-
 
 ## Actions
 
@@ -117,7 +115,6 @@ action "echo", :description => "Echos back any message it receives" do
         :default     => ""
 end
 ```
-
 
 ### Implementing Actions
 
@@ -162,7 +159,7 @@ Accessing via _request.data_ will give you full access to all the normal Hash me
 request[:msg]
 ```
 
-Accesing via _request[]_ will only give you access to _include?_ like behaviour, nil will be returned for unknown keys or data that is not supplied.
+Accessing via _request[]_ will only give you access to _include?_ like behaviour, nil will be returned for unknown keys or data that is not supplied.
 
 #### Running Shell Commands
 
@@ -254,7 +251,6 @@ end
 
 This will search each configured libdir for _mcollective/agent/$agent_name/script.py_ and _agent/$agent_name/script.py_, and will use the former if found. If you specified a full path it will not try to find the file in libdirs.
 
-
 ## Constructing Replies
 
 ### Reply Data
@@ -267,7 +263,7 @@ reply[:msg] = request[:msg]
 
 ### Reply Status
 
-Replies have a strong concept of success or failure indicating the overall success of the request, the table below shows the valid statusses:
+Replies have a strong concept of success or failure indicating the overall success of the request, the table below shows the valid statuses:
 
 |Status Code|Description|Exception Class|
 |-----------|-----------|---------------|

--- a/docs/content/development/mcorpc/applications/_index.md
+++ b/docs/content/development/mcorpc/applications/_index.md
@@ -252,4 +252,3 @@ end
 
 As you can see you pass the _halt_ helper an instance of the RPC Client statistics and it will then
 use that to do the right exit code.
-

--- a/docs/content/development/mcorpc/clients/_index.md
+++ b/docs/content/development/mcorpc/clients/_index.md
@@ -306,9 +306,9 @@ Just note these now, I'll reference them later down.
 
 ### MCollective RPC style results
 
-MCollective RPC provides a trimmed down version of results from the core Client library - RPC being a set of conventions ontop of the core the aim is to make a more user friendly data format for RPC use.
+MCollective RPC provides a trimmed down version of results from the core Client library - RPC being a set of conventions on top of the core the aim is to make a more user friendly data format for RPC use.
 
-This is an important difference between the two approaches, in one you can parse the results as it comes in, in the other you will only get results after processing is done.  This would be the main driving facter for choosing one over the other.
+This is an important difference between the two approaches, in one you can parse the results as it comes in, in the other you will only get results after processing is done.  This would be the main driving factor for choosing one over the other.
 
 Here's an example that will print out results in a custom way.
 

--- a/docs/content/development/mcorpc/ddl/_index.md
+++ b/docs/content/development/mcorpc/ddl/_index.md
@@ -109,7 +109,7 @@ Importantly you do not need to have the _service.rb_ on a machine to use the DDL
 
 You can view a human readable version of this using *mco plugin doc &lt;agent&gt;* command:
 
-```ruby
+```nohighlight
 % mco plugin doc service
 service
 =======
@@ -157,7 +157,7 @@ As you see above the input block has _:type_ option, types can be _:string_, _:l
 
 #### :string type
 
-The string type validates initially that the input is infact a String, then it validates the length of the input and finally matches the supplied Regular Expression.
+The string type validates initially that the input is in fact a String, then it validates the length of the input and finally matches the supplied Regular Expression.
 
 Both _:validation_ and _:maxlength_ are required arguments for the string type of input.
 

--- a/docs/content/development/mcorpc/vaildator/_index.md
+++ b/docs/content/development/mcorpc/vaildator/_index.md
@@ -102,9 +102,7 @@ You can obtain a list of validators using the *plugin* application:
 
 Please specify a plugin. Available plugins are:
 
-.
-.
-.
+<snip>
 
 Validator Plugins:
   array                     Validates that a value is included in a list

--- a/docs/content/development/server/packaging/_index.md
+++ b/docs/content/development/server/packaging/_index.md
@@ -10,6 +10,7 @@ The packaging used to build the open source Choria builds can also be used to bu
 Every Choria build needs a build specification, below we'll show one that build a custom Choria called acme-choria with custom paths and settings. This file goes into `packager/buildspec.yaml`.
 
 ```yaml
+---
 # Flags are variables that can be set by the linker to particular values. These are all String values, if you are linking
 # in your own code you can add variables for those here too, below is the current set of Choria build time settables.  More
 # about their individual uses later in this guide in sections dedicated to types of plugin
@@ -119,13 +120,13 @@ There are a few variables you can use to adjust things for what packages to buil
 
 So to build full set of packages and binaries we do:
 
-```
+```bash
 $ VERSION=1.2.3-acme BUILD=acme PACKAGES=el7_64,bionic_64 rake build
 ```
 
 Or just the binaries
 
-```
+```bash
 $ VERSION=1.2.3-acme BUILD=acme rake build
 ```
 
@@ -201,4 +202,4 @@ I can now build custom builds that copies in my *user_plugins.yaml* and *buildsp
 CHORIA_TAG=0.8.0 PKG_VERSION=0.8.1-acme rake build
 ```
 
-The result will be Choria 0.8.0 with my customizations called *acme-choria-0.8.1-acme.*.rpm*
+The result will be Choria 0.8.0 with my customisations called *acme-choria-0.8.1-acme.*.rpm*

--- a/docs/content/development/server/plugin_interface/_index.md
+++ b/docs/content/development/server/plugin_interface/_index.md
@@ -35,5 +35,5 @@ Thus when you add your plugin to the plugin system like below in `packager/user_
 myplugin: github.com/mycorp/myplugin
 ```
 
-The system will call your *myplugin.ChoriaPlugin()* that should produce a *plugin.Pluggable*. An example of this can be found in the [Golang MCO RPC compatability layer](https://godoc.org/github.com/choria-io/mcorpc-agent-provider/mcorpc/golang).
+The system will call your *myplugin.ChoriaPlugin()* that should produce a *plugin.Pluggable*. An example of this can be found in the [Golang MCO RPC compatibility layer](https://godoc.org/github.com/choria-io/mcorpc-agent-provider/mcorpc/golang).
 

--- a/docs/content/federation/configuration/_index.md
+++ b/docs/content/federation/configuration/_index.md
@@ -23,18 +23,18 @@ Below you'll see DNS records for the 2 SRV Records covering the Federation (left
 
 To discover the middleware for the Federation:
 
-```dns
-_mcollective-federation_server._tcp IN      SRV     0       0       4222    choria1.fed.example.net.
-                                    IN      SRV     0       0       4222    choria2.fed.example.net.
-                                    IN      SRV     0       0       4222    choria3.fed.example.net.
+```nohighlight
+_mcollective-federation_server._tcp IN  SRV 0 0 4222  choria1.fed.example.net.
+                                    IN  SRV 0 0 4222  choria2.fed.example.net.
+                                    IN  SRV 0 0 4222  choria3.fed.example.net.
 ```
 
 To discover the middleware for the Collective:
 
-```dns
-_mcollective-server._tcp            IN      SRV     0       0       4222    choria1.ldn.example.net.
-                                    IN      SRV     0       0       4222    choria2.ldn.example.net.
-                                    IN      SRV     0       0       4222    choria3.ldn.example.net.
+```nohighlight
+_mcollective-server._tcp            IN  SRV 0 0 4222  choria1.ldn.example.net.
+                                    IN  SRV 0 0 4222  choria2.ldn.example.net.
+                                    IN  SRV 0 0 4222  choria3.ldn.example.net.
 ```
 
 {{% notice tip %}}
@@ -51,14 +51,15 @@ While I show the Puppet code here for completeness, I recommend using Hiera to c
 
 ```puppet
 node "nats1.ldn.example.net" {
-  class{"choria":
+  class { "choria":
     srv_domain => "ldn.example.net"
   }
 
-  class{"choria::broker":
-    network_broker => true,
-    federation_broker => true,
+  class { "choria::broker":
+    network_broker     => true,
+    federation_broker  => true,
     federation_cluster => "london",
+
     network_peers => [
       "nats://choria1.ldn.example.net:4223",
       "nats://choria2.ldn.example.net:4223",
@@ -74,9 +75,10 @@ If you wish to configure the middleware manually rather than SRV records you can
 
 ```puppet
   class{"choria::broker":
-    network_broker => true,
-    federation_broker => true,
+    network_broker     => true,
+    federation_broker  => true,
     federation_cluster => "london",
+
     federation_middleware_hosts => [
       "choria1.fed.example.net:4222",
       "choria2.fed.example.net:4222",

--- a/docs/content/playbooks/basics/_index.md
+++ b/docs/content/playbooks/basics/_index.md
@@ -209,7 +209,6 @@ plan acme::slack (
 }
 ```
 
-
 You can run this playbook through the CLI, but lets look at help first, you can see our inputs are provided via *--cluster* or as json.
 
 ```bash

--- a/docs/content/playbooks/node_sets/_index.md
+++ b/docs/content/playbooks/node_sets/_index.md
@@ -113,7 +113,7 @@ $nodes = choria::discover("pql",
 )
 ```
 
-All non deactivated certnames will be extracted and used as discovery source. This also shows how to use a input variable and a reminder you should test MCollectivity connectivity to this sort of node set
+All non deactivated certnames will be extracted and used as discovery source. This also shows how to use a input variable and a reminder you should test MCollective connectivity to this sort of node set.
 
 |Option|Description|Sample|
 |------|-----------|------|
@@ -134,7 +134,6 @@ The script should just output one certname per line. It supports any arguments y
 {{% notice warning %}}
 I strongly suggest you validate any input you use as arguments here to not include things that might cause shell escapes.  You can do this using the `Choria::ShellSafe` data type.
 {{% /notice %}}
-
 
 |Option|Description|Sample|
 |------|-----------|------|

--- a/docs/content/playbooks/tips/_index.md
+++ b/docs/content/playbooks/tips/_index.md
@@ -96,18 +96,18 @@ The key to error handling is to pass `_catch_errors => true` to *choria::run_pla
 choria::run_playbook("example::app_upgrade", _catch_errors => true,
   "action" => "appmgr.restart",
   "nodes" => $nodes)
-
     .choria::on_error |Choria::TaskResults $err| {
       notice("Application upgrade failed: ${err.message}, recovering using example::recover")
 
-      choria::run_playbook("example::rocover",
+      choria::run_playbook("example::recover",
         "cluster" => $cluster
       )
 
-      fail("deploying cluster ${cluster} failed, recovery run succesfully")}
-
+      fail("deploying cluster ${cluster} failed, recovery run successfully")
+    }
     .choria::on_success |Choria::TaskResults $results| {
-      notice("deployment succesful on cluster ${cluster}")}
+      notice("deployment successful on cluster ${cluster}")
+    }
 ```
 
 This syntax might be a bit foreign to Puppet users, here's another approach but now you need temporary variables which can be very annoying:
@@ -119,15 +119,15 @@ $result = choria::task("mcollective", _catch_errors => true,
 )
 
 $result.choria::on_error |$results| {
-  choria::run_playbook("example::rocover",
+  choria::run_playbook("example::recover",
     "cluster" => $cluster
   )
 
-  fail("deploying cluster ${cluster} failed, recovery run succesfully")
+  fail("deploying cluster ${cluster} failed, recovery run successfully")
 }
 
 $result.choria::on_success |$results| {
-  notice("deployment succesful on cluster ${cluster}")
+  notice("deployment successful on cluster ${cluster}")
 }
 ```
 

--- a/docs/content/tasks/usage/_index.md
+++ b/docs/content/tasks/usage/_index.md
@@ -72,11 +72,11 @@ Use 'mco tasks run puppet_conf' to run this task
 
 ### Running a Task
 
-Tasks are always run dissociated from the MCollectived, you can therefore use them to restart MCollective, do system upgrades and other long running tasks.
+Tasks are always run dissociated from the *mcollectived*, you can therefore use them to restart MCollective, do system upgrades and other long running tasks.
 
 Lets look at the task input first
 
-```
+```nohighlight
 $ mco tasks run puppet_conf
 The action option is mandatory
 The setting option is mandatory
@@ -84,7 +84,7 @@ The setting option is mandatory
 Please run with --help for detailed help
 ```
 
-```
+```nohighlight
 $ mco tasks run puppet_conf --help
 
 Puppet Task Orchestrator
@@ -109,7 +109,7 @@ Application Options
     -h, --help                       Display this screen
 ```
 
-I've removed the bulk of the Help output here, the thing to note are the parameters like _--action, these are inputs defined by the task exposed on the CLI.
+I've removed the bulk of the Help output here, the thing to note are the parameters like _--action_, these are inputs defined by the task exposed on the CLI.
 
 In most cases Choria will attempt to convert a string like _1_ into an Integer when that is what the task need so for most tasks you can pass the options as normal.  You can though also use a YAML or JSON file as input, for example:
 
@@ -185,12 +185,12 @@ Requesting task metadata for request 45250c07824f5922be68468d08f6b76c
 
 
 Finished processing 1 / 1 hosts in 171.36 ms
-</code></pre>
+```
 
-And finally you can retrieve all the output and statusses as JSON:
+And finally you can retrieve all the output and statuses as JSON:
 
-<pre><code class="nohighlight">
-$ mco tasks status 45250c07824f5922be68468d08f6b76c --json -I node1.example.net|jq .
+```nohighlight
+$ mco tasks status 45250c07824f5922be68468d08f6b76c --json -I node1.example.net | jq .
 {
   "items": [
     {


### PR DESCRIPTION
This contains mostly spell checking - some changes of American English
to British English.  Additionally:

* Common typos fixed.  Hopefully.
* Inconsistent capitialization of terms, like 'Subcollective'
 * Probably worth making a style guide for this
* Upstream docs on CFSSL
* Conversion of HTML to markdown
* /usr/bin/env is more consistent across unices, IMHO
* Blank lines - apparently there's a markdown linter, and I have it installed
* syntax highlighting plugin, chaning various things that looked awful to `nohighlight`
* spaces vs tabs - only for command output examples - specifically DNS
* line up puppet arrows like the style guide says