### PR TITLE
Remove legacy hiera config

### DIFF
--- a/docs/content/configuration/choria_server/_index.md
+++ b/docs/content/configuration/choria_server/_index.md
@@ -49,8 +49,6 @@ On all your nodes where you wish to run the new service:
 ```yaml
 choria::server: true
 choria::manage_package_repo: true
-mcollective::service_ensure: stopped
-mcollective::service_enable: false
 ```
 
 On all nodes including those that are pure MCollective and your clients:


### PR DESCRIPTION
The mcollectived service is being phased out.  Remove old configuration related to it.

Somme commands output in `docs/content/deployment/next-steps/_index.md` needs updating but I do not have access to a Linux installed with AIO packages so I will open an issue to remember to update these examples with "fresh" data (#81)…